### PR TITLE
fixed path in code coverage generator

### DIFF
--- a/packages/coverage/generate_coverage.sh
+++ b/packages/coverage/generate_coverage.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd ..
+cd ../..
 php ./extensions/coverage/bin/php-coverage-open.php \
 	--exclude='.*/test/.*' \
     --exclude='.*DB.common.php$' \


### PR DESCRIPTION
the cd command has to go one level higher to find the php files
