### PR TITLE
Allow use of ReferenceExpectation in expect calls

### DIFF
--- a/expectation.php
+++ b/expectation.php
@@ -91,8 +91,10 @@ class SimpleExpectation {
      *    @access public
      */
     static function isExpectation($expectation) {
-        return is_object($expectation) &&
-                SimpleTestCompatibility::isA($expectation, 'SimpleExpectation');
+        return is_object($expectation) && (
+            SimpleTestCompatibility::isA($expectation, 'SimpleExpectation') ||
+            SimpleTestCompatibility::isA($expectation, 'ReferenceExpectation')
+        );
     }
 }
 


### PR DESCRIPTION
ReferenceExpectation does not [inherit from EqualException](https://github.com/simpletest/simpletest/issues/7) (it's logical
parent), and is unable to do so while maintaining PHP4 compatability
(the byref ampersands would need removing) so instead, add a case to
recognise it as a valid exception in SimpleExpectation::isExpectation.