### PR TITLE
PHP 5 doesn't need these, and later versions warn

### DIFF
--- a/compatibility.php
+++ b/compatibility.php
@@ -102,7 +102,7 @@ class SimpleTestCompatibility {
      *    @return boolean        True if same.
      *    @access public
      */
-    static function isReference(&$first, &$second) {
+    static function isReference($first, $second) {
         if (version_compare(phpversion(), '5', '>=') && is_object($first)) {
             return ($first === $second);
         }


### PR DESCRIPTION
Managed to commit without these when throwing together the previous PR! >_>;;