### PR TITLE
Add support for mocking variadic methods

### DIFF
--- a/reflection_php5.php
+++ b/reflection_php5.php
@@ -368,8 +368,13 @@ class SimpleReflection
             if ($parameter->isPassedByReference()) {
                 $signature .= '&';
             }
+            // Variadic methods only supported in PHP 5.6+, so guard the call
+            $isVariadic = version_compare(phpversion(), '5.6.0', '>=') && $parameter->isVariadic();
+            if ($isVariadic) {
+                $signature .= '...';
+            }
             $signature .= '$' . $this->suppressSpurious($parameter->getName());
-            if ($this->isOptional($parameter)) {
+            if (!$isVariadic && $this->isOptional($parameter)) {
                 $signature .= ' = null';
             }
             $signatures[] = $signature;


### PR DESCRIPTION
Not sure how to test this as creating a fake class with a variadic method would also need to be guarded against lesser PHP versions… feedback on the best way to approach would be welcomed.