### PR TITLE
Access to original constructor in mocks

### DIFF
--- a/mock_objects.php
+++ b/mock_objects.php
@@ -1448,6 +1448,7 @@ class MockGenerator
         $code .= "    function __construct() {\n";
         $code .= "        parent::__construct();\n";
         $code .= "    }\n";
+        $code .= $this->createConstructorCode();
         $code .= $this->createHandlerCode($methods);
         $code .= "}\n";
         return $code;
@@ -1469,6 +1470,7 @@ class MockGenerator
         $code .= "        \$this->mock = new " . $this->mock_base . "();\n";
         $code .= "        \$this->mock->disableExpectationNameChecks();\n";
         $code .= "    }\n";
+        $code .= $this->createConstructorCode();
         $code .= $this->chainMockReturns();
         $code .= $this->chainMockExpectations();
         $code .= $this->chainThrowMethods();
@@ -1499,6 +1501,7 @@ class MockGenerator
         $code .= "        \$this->mock = new " . $this->mock_base . "();\n";
         $code .= "        \$this->mock->disableExpectationNameChecks();\n";
         $code .= "    }\n";
+        $code .= $this->createConstructorCode();
         $code .= $this->chainMockReturns();
         $code .= $this->chainMockExpectations();
         $code .= $this->chainThrowMethods();
@@ -1599,6 +1602,19 @@ class MockGenerator
         $code .= "            \$null = null;\n";
         $code .= "            return \$null;\n";
         $code .= "        }\n";
+        return $code;
+    }
+
+    /**
+     *    Creates source code for late calling the constructor of the
+     *    compositied mock object.
+     *    @return string           Code for late calls.
+     */
+    protected function createConstructorCode()
+    {
+        $code  = "    function __constructor() {\n";
+        $code .= "        call_user_func_array('parent::__construct', func_get_args());\n";
+        $code .= "    }\n";
         return $code;
     }
 

--- a/test/mock_objects_test.php
+++ b/test/mock_objects_test.php
@@ -219,8 +219,11 @@ class TestOfCallSchedule extends UnitTestCase
 
 class Dummy
 {
+    public $init = false;
+
     public function __construct()
     {
+        $this->init = true;
     }
 
     public function aMethod()
@@ -241,6 +244,30 @@ class Dummy
 Mock::generate('Dummy');
 Mock::generate('Dummy', 'AnotherMockDummy');
 Mock::generate('Dummy', 'MockDummyWithExtraMethods', array('extraMethod'));
+
+class TestOfConstructorCreation extends UnitTestCase
+{
+    public function testCloning()
+    {
+        $mock = new MockDummy();
+        $this->assertTrue(method_exists($mock, "__constructor"));
+        $this->assertFalse($mock->init);
+        $this->assertNull($mock->__constructor());
+        $this->assertTrue($mock->init);
+    }
+
+    public function testCloningWithExtraMethod()
+    {
+        $mock = new MockDummyWithExtraMethods();
+        $this->assertTrue(method_exists($mock, "__constructor"));
+    }
+
+    public function testCloningWithChosenClassName()
+    {
+        $mock = new AnotherMockDummy();
+        $this->assertTrue(method_exists($mock, "__constructor"));
+    }
+}
 
 class TestOfMockGeneration extends UnitTestCase
 {


### PR DESCRIPTION
Neccessarily mocks override `__construct`, however it's sometimes
desirable to be able to bootstrap a mock using the code within. This
commit introduces the `__constructor` method, which exists for the
purpose of being able to run the original `__construct` code in mocks.

This also facilitates the late calling of `__construct`, i.e. after an
instance has been created.

Fixes #13