### PR TITLE
Fix for error on getTagName() object

### DIFF
--- a/php_parser.php
+++ b/php_parser.php
@@ -852,7 +852,7 @@ class SimplePhpPageBuilder
         }
         if ($this->hasNamedTagOnOpenTagStack($name)) {
             $tag = array_pop($this->tags[$name]);
-            if ($tag->isPrivateContent() && $this->private_content_tag->getTagName() == $name) {
+            if ($tag->isPrivateContent() && is_object($this->private_content_tag) && $this->private_content_tag->getTagName() == $name) {
                 unset($this->private_content_tag);
             }
             $this->addContentTagToOpenTags($tag);


### PR DESCRIPTION
Hi, I came across this issue and fixed it by adding is_object to $this->private_content_tag before executing the $this->private_content_tag->getTagName() method. Below is the error message. Please update.

PHP Fatal error:  Call to a member function getTagName() on a non-object in /vendor/simpletest/simpletest/php_parser.php on line 876
