### PR TITLE
Using the modern versionless html DOCTYPE:

### DIFF
--- a/docs/simpletest.org/index.html
+++ b/docs/simpletest.org/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <title>SimpleTest - Unit Testing for PHP</title>

--- a/extensions/js/tests/TestOfWebunit.js.html
+++ b/extensions/js/tests/TestOfWebunit.js.html
@@ -1,5 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 <html>
 <head>
 <title>JsUnit Tests of webunit.js</title>

--- a/packages/simpletest.org/template.html
+++ b/packages/simpletest.org/template.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/reporter.php
+++ b/reporter.php
@@ -30,7 +30,7 @@ class HtmlReporter extends SimpleReporter
     public function paintHeader($test_name)
     {
         $this->sendNoCacheHeaders();
-        print '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">';
+        print '<!DOCTYPE html>';
         print "<html>\n<head>\n<title>$test_name</title>\n";
         print '<meta http-equiv="Content-Type" content="text/html; charset=' . $this->charset . "\">\n";
         print "<style type=\"text/css\">\n";


### PR DESCRIPTION
HTML is now versionless. This means to the extent browsers
choose to support outdated HTML elements, attributes, etc, they do
this as a single version of HTML. Using a different doctype is not
supposed to alter how the browser behaves.