### PR TITLE
support input tags of type time and date

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,7 @@
 * fixed #17 - Access to original constructor in mocks (@mal)
 * fixed return "exit code" of true/1, when tests are passing
 * fixed #14 - Add support for mocking variadic methods (@36degrees)
+* added support for inputs of type date and time
 
 ## [1.1.7] - 2015-09-21
 

--- a/docs/source/en/form_testing_documentation.xml
+++ b/docs/source/en/form_testing_documentation.xml
@@ -126,6 +126,8 @@ class SimpleFormTests extends WebTestCase {
                     <li>Drop down selections, including multiple selects.</li>
                     <li>Radio buttons.</li>
                     <li>Images.</li>
+                    <li>Date fields.</li>
+                    <li>Time fields, including the step attribute.</li>
                 </ul>
             </p>
             <p>
@@ -225,7 +227,7 @@ class SimpleFormTests extends WebTestCase {
 ]]></php>
                 Bear in mind that in doing this you're effectively stubbing out a
                 part of your software (the javascript code in the form), and
-                perhaps you might be better off using something like 
+                perhaps you might be better off using something like
                 <a href="http://selenium.openqa.org/">Selenium</a> to ensure a complete
                 test.
             </p>
@@ -237,7 +239,7 @@ class SimpleFormTests extends WebTestCase {
                 form submission by hand.
 <php><![CDATA[
 class SimpleFormTests extends WebTestCase {
-    ...<strong>    
+    ...<strong>
     function testAttemptedHack() {
         $this->post(
                 'http://www.my-site.com/add_user.php',

--- a/tag.php
+++ b/tag.php
@@ -82,6 +82,8 @@ class SimpleTagBuilder
             'text'     => 'SimpleTextTag',
             'hidden'   => 'SimpleTextTag',
             'password' => 'SimpleTextTag',
+            'date'     => 'SimpleDateTag',
+            'time'     => 'SimpleTimeTag',
             'file'     => 'SimpleUploadTag'
         );
         if (array_key_exists($type, $map)) {
@@ -1238,6 +1240,86 @@ class SimpleCheckboxTag extends SimpleWidget
         }
 
         return false;
+    }
+}
+
+/**
+ * Date field.
+ */
+class SimpleDateTag extends SimpleTextTag
+{
+    /**
+     * Sets the current form element value.
+     *
+     * Date value must be empty or parseable by strtotime, e.g. 2019-09-06.
+     * The step attribute is not supported because timezones.
+     *
+     * @param string $value       New date value.
+     *
+     * @return bool            True if allowed.
+     */
+    public function setValue($value)
+    {
+        if (!empty($value)) {
+            $time = strtotime($value);
+
+            if ($time === false) {
+                return false;
+            } else {
+                $value = date("Y-m-d", $time);
+            }
+        }
+
+        return parent::setValue($value);
+    }
+}
+
+/**
+ * Time field.
+ */
+class SimpleTimeTag extends SimpleTextTag
+{
+    /**
+     * Sets the current form element value.
+     *
+     * Time value must be empty or parseable by strtotime, e.g. 23:59:59.
+     * The value must also be compatible with the element's step attribute.
+     * A step attribute that is a multiple of 60 seconds results in the HH:MM
+     * format; otherwise, HH:MM:SS is used.
+     *
+     * @param string $value       New time value.
+     *
+     * @return bool            True if allowed.
+     */
+    public function setValue($value)
+    {
+        if (!empty($value)) {
+            $time = strtotime($value);
+
+            if ($time === false) {
+                return false;
+            } else {
+                $step = $this->getAttribute('step');
+
+                if ($step === false) {
+                    $step = 60;
+                } else {
+                    $step = intval($step);
+                }
+
+                if ($time % $step > 0) {
+                    return false;
+                }
+
+                if ($step % 60 === 0) {
+                    $value = date("H:i", $time);
+                } else {
+                    $value = date("H:i:s", $time);
+                }
+            }
+        }
+
+        return parent::setValue($value);
     }
 }
 

--- a/test/tag_test.php
+++ b/test/tag_test.php
@@ -95,6 +95,53 @@ class TestOfWidget extends UnitTestCase
         $this->assertEqual($tag->getValue(), 'aaa');
     }
 
+    public function testDateDefault()
+    {
+        $tag = new SimpleDateTag(array('value' => '2019-09-06'));
+        $this->assertEqual($tag->getDefault(), '2019-09-06');
+        $this->assertEqual($tag->getValue(), '2019-09-06');
+    }
+
+    public function testSettingDateValue()
+    {
+        $tag = new SimpleDateTag(array('value' => '2019-09-06'));
+        $this->assertTrue($tag->setValue('2011-11-11'));
+        $this->assertEqual($tag->getValue(), '2011-11-11');
+        $tag->resetValue();
+        $this->assertEqual($tag->getValue(), '2019-09-06');
+    }
+
+    public function testTimeDefault()
+    {
+        $tag = new SimpleTimeTag(array('value' => '10:33:42'));
+        $this->assertEqual($tag->getDefault(), '10:33:42');
+        $this->assertEqual($tag->getValue(), '10:33:42');
+    }
+
+    public function testSettingTimeValue()
+    {
+        $tag = new SimpleTimeTag(array('value' => '10:33'));
+        $tag->setValue('11:11');
+        $this->assertEqual($tag->getValue(), '11:11');
+        $tag->resetValue();
+        $this->assertEqual($tag->getValue(), '10:33');
+    }
+
+    public function testTimeStepAttribute()
+    {
+        $tag = new SimpleTimeTag(array());
+        $this->assertFalse($tag->setValue('10:33:42'));
+        $this->assertTrue($tag->setValue('10:33'));
+        $this->assertTrue($tag->setValue('10:33:00'));
+        $this->assertEqual($tag->getValue(), '10:33');
+
+        $tag = new SimpleTimeTag(array('step' => '5'));
+        $this->assertEqual($tag->getAttribute('step'), '5');
+        $this->assertFalse($tag->setValue('10:33:42'));
+        $this->assertTrue($tag->setValue('10:33:45'));
+        $this->assertEqual($tag->getValue(), '10:33:45');
+    }
+
     public function testFailToSetHiddenValue()
     {
         $tag = new SimpleTextTag(array('value' => 'aaa', 'type' => 'hidden'));


### PR DESCRIPTION
- time inputs support the step attribute
- time inputs select a format appropriate for its step attribute
- mention that time and date fields are supported in docs
- update changelog