### PR TITLE
Fix mocking, fix tests, don't support dead PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,11 @@ addons:
     packages:
       - parallel
 
-php: [5.5, 5.6, 7, 7.1]
+php: [7.1, 7.2, 7.3]
 
 matrix:
+    allow_failures:
+        - php: 7.1
     fast_finish: true
 
 script:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-SimpleTest [![Build Status](https://travis-ci.org/simpletest/simpletest.svg)](https://travis-ci.org/simpletest/simpletest) [![Latest Stable Version](https://img.shields.io/packagist/v/simpletest/simpletest.svg?style=flat-square)](https://packagist.org/packages/simpletest/simpletest) [![Total Downloads](https://img.shields.io/packagist/dt/simpletest/simpletest.svg?style=flat-square)](https://packagist.org/packages/simpletest/simpletest) [![Latest Unstable Version](https://poser.pugx.org/simpletest/simpletest/v/unstable)](https://packagist.org/packages/simpletest/simpletest) 
+SimpleTest [![Build Status](https://travis-ci.org/simpletest/simpletest.svg)](https://travis-ci.org/simpletest/simpletest) [![Latest Stable Version](https://img.shields.io/packagist/v/simpletest/simpletest.svg?style=flat-square)](https://packagist.org/packages/simpletest/simpletest) [![Total Downloads](https://img.shields.io/packagist/dt/simpletest/simpletest.svg?style=flat-square)](https://packagist.org/packages/simpletest/simpletest) [![Latest Unstable Version](https://poser.pugx.org/simpletest/simpletest/v/unstable)](https://packagist.org/packages/simpletest/simpletest)
 ==========
 
 SimpleTest is a framework for unit testing, web site testing and mock objects for PHP.
@@ -47,7 +47,7 @@ StackOverflow offers also a good collection of [SimpleTest related questions](ht
 
 ### Requirements
 
-PHP 5.4+
+PHP 7.1+
 
 ### Authors
 
@@ -61,12 +61,12 @@ PHP 5.4+
 
 ### License
 
-GNU LGPL v2.1 
+GNU LGPL v2.1
 
 ### Tests
 
 The unit tests for SimpleTest itself can be run here:
- 
+
     test/all_tests.php
 
 The acceptance tests require a running server:

--- a/extensions/phpunit/PHPUnitTestCase.php
+++ b/extensions/phpunit/PHPUnitTestCase.php
@@ -70,7 +70,7 @@ class PHPUnitTestCase extends SimpleTestCase
      * @param $second         Hopefully the same handle.
      * @param $message        Message to display.
      */
-    public function assertSame($first, $second, $message = '%s')
+    public function assertSame(&$first, &$second, $message = '%s')
     {
         $dumper  = new SimpleDumper();
         $message = sprintf(

--- a/mock_objects.php
+++ b/mock_objects.php
@@ -704,7 +704,7 @@ class SimpleMock
         $this->max_counts       = array();
         $this->expected_args    = array();
         $this->expected_args_at = array();
-        $current_test_case      = $this->getCurrentTestCase();        
+        $current_test_case      = $this->getCurrentTestCase();
         if ($current_test_case) {
             $current_test_case->tell($this);
         }
@@ -742,7 +742,9 @@ class SimpleMock
         if (! is_array($args)) {
             $errormsg = sprintf('Cannot %s. Parameter %s is not an array.', $task, $args);
             trigger_error($errormsg, E_USER_ERROR);
+            return false;
         }
+        return true;
     }
 
     /**
@@ -756,7 +758,9 @@ class SimpleMock
         if ($this->is_strict && ! method_exists($this, $method)) {
             $errormsg = sprintf('Cannot %s. Method %s() not in class %s.', $task, $method, get_class($this));
             trigger_error($errormsg, E_USER_ERROR);
+            return false;
         }
+        return true;
     }
 
     /**
@@ -911,8 +915,12 @@ class SimpleMock
      */
     public function expect($method, $args, $message = '%s')
     {
-        $this->dieOnNoMethod($method, 'set expected arguments');
-        $this->checkArgumentsIsArray($args, 'set expected arguments');
+        $ok = true;
+        $ok = $ok && $this->dieOnNoMethod($method, 'set expected arguments');
+        $ok = $ok && $this->checkArgumentsIsArray($args, 'set expected arguments');
+        if (!$ok) {
+            return;
+        }
         $this->expectations->expectArguments($method, $args, $message);
         $args = $this->replaceWildcards($args);
         $message .= Mock::getExpectationLine();
@@ -1403,7 +1411,7 @@ class MockGenerator
      */
     protected function createCodeForClass($methods)
     {
-        $implements = '';        
+        $implements = '';
         $interfaces = $this->reflection->getInterfaces();
 
         // exclude interfaces

--- a/reflection.php
+++ b/reflection.php
@@ -371,12 +371,12 @@ class SimpleReflection
                 $returnType = "\\".$this->method->getDeclaringClass()->getName();
             }
 
-            // Guard: method getReturnType()->allowsNull() is only supported by PHP7.1+
-            if(PHP_VERSION_ID >= 70100) {
-                $returnType = '?'.$returnType;
-            }
-
             if($returnType != '') {
+                // Guard: method getReturnType()->allowsNull() is only supported by PHP7.1+
+                if(PHP_VERSION_ID >= 70100) {
+                    $returnType = '?'.$returnType;
+                }
+
                 return ': '. $returnType;
             }
         } 

--- a/test/browser_test.php
+++ b/test/browser_test.php
@@ -401,6 +401,7 @@ class TestOfBrowserNavigation extends UnitTestCase
 
         $page = new MockSimplePage();
         $page->returnsByValue('getUrlById', false);
+        $page->returnsByValue('getUrlsByLabel', array());
 
         $browser = $this->createBrowser($agent, $page);
         $browser->get('http://this.com/page.html');

--- a/test/browser_test.php
+++ b/test/browser_test.php
@@ -167,7 +167,7 @@ class TestOfParsedPageAccess extends UnitTestCase
         $browser = new MockParseSimpleBrowser($this);
         $browser->returns('createUserAgent', $agent);
         $browser->returns('parse', $page);
-        $browser->__construct();
+        $browser->__constructor();
 
         $browser->get('http://this.com/page.html');
 
@@ -179,7 +179,7 @@ class TestOfParsedPageAccess extends UnitTestCase
         $agent   = new MockSimpleUserAgent($this);
         $browser = new MockParseSimpleBrowser($this);
         $browser->returns('createUserAgent', $agent);
-        $browser->__construct();
+        $browser->__constructor();
         $this->assertEqual($browser->getContent(), '');
     }
 
@@ -245,7 +245,7 @@ class TestOfBrowserNavigation extends UnitTestCase
         $browser = new MockParseSimpleBrowser();
         $browser->returns('createUserAgent', $agent);
         $browser->returns('parse', $page);
-        $browser->__construct();
+        $browser->__constructor();
 
         return $browser;
     }
@@ -592,7 +592,7 @@ class TestOfBrowserFrames extends UnitTestCase
     {
         $browser = new MockUserAgentSimpleBrowser();
         $browser->returns('createUserAgent', $agent);
-        $browser->__construct();
+        $browser->__constructor();
 
         return $browser;
     }

--- a/test/dumper_test.php
+++ b/test/dumper_test.php
@@ -18,8 +18,10 @@ class TestOfTextFormatting extends UnitTestCase
         $this->assertEqual($dumper->clipString('Hello world', 3, 6), '...o w...', 'Hello world, 3, 6->%s');
         $this->assertEqual($dumper->clipString('Hello world', 4, 11), '...orld', 'Hello world, 4, 11->%s');
         $this->assertEqual($dumper->clipString('Hello world', 4, 12), '...orld', 'Hello world, 4, 12->%s');
-        $this->assertEqual($dumper->clipString('Seine Majestät, der König von Zamunda', 31), 
-            'Seine Majestät, der König von...', 'Seine Majestät, der König von Zamunda, 31, 31->%s');
+        $this->assertEqual($dumper->clipString('Seine Majestät, der König von Zamunda', 29),
+            'Seine Majestät, der König von...', 'Seine Majestät, der König von Zamunda, 29, 29->%s');
+        $this->assertEqual($dumper->clipString('Seine Majestet, der Konig von Zamunda', 29),
+            'Seine Majestet, der Konig von...', 'Seine Majestat, der Konig von Zamunda, 29, 29->%s');
     }
 
     public function testDescribeNull()

--- a/test/http_test.php
+++ b/test/http_test.php
@@ -23,7 +23,7 @@ class TestOfDirectRoute extends UnitTestCase
         $socket->expectCallCount('write', 3);
         $route = new PartialSimpleRoute();
         $route->returnsByReference('createSocket', $socket);
-        $route->__construct(new SimpleUrl('http://a.valid.host/here.html'));
+        $route->__constructor(new SimpleUrl('http://a.valid.host/here.html'));
         $this->assertSame($route->createConnection('GET', 15), $socket);
     }
 
@@ -36,7 +36,7 @@ class TestOfDirectRoute extends UnitTestCase
         $socket->expectCallCount('write', 3);
         $route = new PartialSimpleRoute();
         $route->returnsByReference('createSocket', $socket);
-        $route->__construct(new SimpleUrl('http://a.valid.host/here.html'));
+        $route->__constructor(new SimpleUrl('http://a.valid.host/here.html'));
 
         $route->createConnection('POST', 15);
     }
@@ -50,7 +50,7 @@ class TestOfDirectRoute extends UnitTestCase
         $socket->expectCallCount('write', 3);
         $route = new PartialSimpleRoute();
         $route->returnsByReference('createSocket', $socket);
-        $route->__construct(new SimpleUrl('http://a.valid.host/here.html'));
+        $route->__constructor(new SimpleUrl('http://a.valid.host/here.html'));
         $this->assertSame($route->createConnection('DELETE', 15), $socket);
     }
 
@@ -63,7 +63,7 @@ class TestOfDirectRoute extends UnitTestCase
         $socket->expectCallCount('write', 3);
         $route = new PartialSimpleRoute();
         $route->returnsByReference('createSocket', $socket);
-        $route->__construct(new SimpleUrl('http://a.valid.host/here.html'));
+        $route->__constructor(new SimpleUrl('http://a.valid.host/here.html'));
         $this->assertSame($route->createConnection('HEAD', 15), $socket);
     }
 
@@ -77,7 +77,7 @@ class TestOfDirectRoute extends UnitTestCase
 
         $route = new PartialSimpleRoute();
         $route->returnsByReference('createSocket', $socket);
-        $route->__construct(new SimpleUrl('http://a.valid.host:81/here.html'));
+        $route->__constructor(new SimpleUrl('http://a.valid.host:81/here.html'));
 
         $route->createConnection('GET', 15);
     }
@@ -92,7 +92,7 @@ class TestOfDirectRoute extends UnitTestCase
 
         $route = new PartialSimpleRoute();
         $route->returnsByReference('createSocket', $socket);
-        $route->__construct(new SimpleUrl('http://a.valid.host/here.html?a=1&b=2'));
+        $route->__constructor(new SimpleUrl('http://a.valid.host/here.html?a=1&b=2'));
 
         $route->createConnection('GET', 15);
     }
@@ -110,7 +110,7 @@ class TestOfProxyRoute extends UnitTestCase
 
         $route = new PartialSimpleProxyRoute();
         $route->returnsByReference('createSocket', $socket);
-        $route->__construct(
+        $route->__constructor(
         new SimpleUrl('http://a.valid.host/here.html'),
         new SimpleUrl('http://my-proxy'));
         $route->createConnection('GET', 15);
@@ -126,7 +126,7 @@ class TestOfProxyRoute extends UnitTestCase
 
         $route = new PartialSimpleProxyRoute();
         $route->returnsByReference('createSocket', $socket);
-        $route->__construct(
+        $route->__constructor(
         new SimpleUrl('http://a.valid.host/here.html'),
         new SimpleUrl('http://my-proxy'));
         $route->createConnection('POST', 15);
@@ -142,7 +142,7 @@ class TestOfProxyRoute extends UnitTestCase
 
         $route = new PartialSimpleProxyRoute();
         $route->returnsByReference('createSocket', $socket);
-        $route->__construct(
+        $route->__constructor(
         new SimpleUrl('http://a.valid.host:81/here.html'),
         new SimpleUrl('http://my-proxy:8081'));
         $route->createConnection('GET', 15);
@@ -158,7 +158,7 @@ class TestOfProxyRoute extends UnitTestCase
 
         $route = new PartialSimpleProxyRoute();
         $route->returnsByReference('createSocket', $socket);
-        $route->__construct(
+        $route->__constructor(
         new SimpleUrl('http://a.valid.host/here.html?a=1&b=2'),
         new SimpleUrl('http://my-proxy'));
         $route->createConnection('GET', 15);
@@ -177,7 +177,7 @@ class TestOfProxyRoute extends UnitTestCase
 
         $route = new PartialSimpleProxyRoute();
         $route->returnsByReference('createSocket', $socket);
-        $route->__construct(
+        $route->__constructor(
         new SimpleUrl('http://a.valid.host/here.html'),
         new SimpleUrl('http://my-proxy'),
                 'Me',

--- a/test/interfaces_test.php
+++ b/test/interfaces_test.php
@@ -29,7 +29,11 @@ class TestOfMockInterfaces extends UnitTestCase
     {
         $mock = new MockDummyInterface();
         $this->expectError();
-        $mock->anotherMethod();
+        try {
+            $mock->anotherMethod();
+        } catch (Error $e) {
+            trigger_error($e->getMessage());
+        }
     }
 
     public function testCannotPartiallyMockAnInterface()

--- a/test/mock_objects_test.php
+++ b/test/mock_objects_test.php
@@ -535,6 +535,7 @@ SimpleTest::setMockBaseClass('MockWithInjectedTestCase');
 Mock::generate('Dummy', 'MockDummyWithInjectedTestCase');
 SimpleTest::setMockBaseClass('SimpleMock');
 Mock::generate('SimpleTestCase');
+SimpleTest::ignore('MockSimpleTestCase');
 
 class LikeExpectation extends IdenticalExpectation
 {

--- a/test/user_agent_test.php
+++ b/test/user_agent_test.php
@@ -43,7 +43,8 @@ class TestOfAdditionalHeaders extends UnitTestCase
     public function testAdditionalHeaderAddedToRequest()
     {
         $response = new MockSimpleHttpResponse();
-        $response->returnsByReference('getHeaders', new MockSimpleHttpHeaders());
+        $mockHeaders = new MockSimpleHttpHeaders();
+        $response->returnsByReference('getHeaders', $mockHeaders);
 
         $request = new MockSimpleHttpRequest();
         $request->returnsByReference('fetch', $response);
@@ -66,8 +67,8 @@ class TestOfBrowserCookies extends UnitTestCase
         $response = new MockSimpleHttpResponse();
         $response->returnsByValue('isError', false);
         $response->returnsByValue('getContent', 'stuff');
-        $response->returnsByReference('getHeaders', new MockSimpleHttpHeaders());
-
+        $mockHeaders = new MockSimpleHttpHeaders();
+        $response->returnsByReference('getHeaders', $mockHeaders);
         return $response;
     }
 
@@ -357,7 +358,8 @@ class TestOfAuthorisation extends UnitTestCase
     public function testAuthenticateHeaderAdded()
     {
         $response = new MockSimpleHttpResponse();
-        $response->returnsByReference('getHeaders', new MockSimpleHttpHeaders());
+        $mockHeaders = new MockSimpleHttpHeaders();
+        $response->returnsByReference('getHeaders', $mockHeaders);
 
         $request = new MockSimpleHttpRequest();
         $request->returns('fetch', $response);

--- a/test/user_agent_test.php
+++ b/test/user_agent_test.php
@@ -29,7 +29,7 @@ class TestOfFetchingUrlParameters extends UnitTestCase
 
         $agent = new MockRequestUserAgent();
         $agent->returns('createHttpRequest', $this->request);
-        $agent->__construct();
+        $agent->__constructor();
 
         $response = $agent->fetchResponse(
                 new SimpleUrl('http://test:secret@this.com/page.html'),
@@ -54,7 +54,7 @@ class TestOfAdditionalHeaders extends UnitTestCase
 
         $agent = new MockRequestUserAgent();
         $agent->returnsByReference('createHttpRequest', $request);
-        $agent->__construct();
+        $agent->__constructor();
         $agent->addHeader('User-Agent: SimpleTest');
         $response = $agent->fetchResponse(new SimpleUrl('http://this.host/'), new SimpleGetEncoding());
     }
@@ -89,7 +89,7 @@ class TestOfBrowserCookies extends UnitTestCase
     {
         $agent = new MockRequestUserAgent();
         $agent->returnsByReference('createHttpRequest', $request);
-        $agent->__construct();
+        $agent->__constructor();
 
         return $agent;
     }
@@ -235,7 +235,7 @@ class TestOfHttpRedirects extends UnitTestCase
                 'createHttpRequest',
                 $this->createRedirect('stuff', 'there.html'));
         $agent->expectOnce('createHttpRequest');
-        $agent->__construct();
+        $agent->__constructor();
         $agent->setMaximumRedirects(0);
         $response = $agent->fetchResponse(new SimpleUrl('here.html'), new SimpleGetEncoding());
         $this->assertEqual($response->getContent(), 'stuff');
@@ -253,7 +253,7 @@ class TestOfHttpRedirects extends UnitTestCase
                 'createHttpRequest',
                 $this->createRedirect('second', 'three.html'));
         $agent->expectCallCount('createHttpRequest', 2);
-        $agent->__construct();
+        $agent->__constructor();
 
         $agent->setMaximumRedirects(1);
         $response = $agent->fetchResponse(new SimpleUrl('one.html'), new SimpleGetEncoding());
@@ -276,7 +276,7 @@ class TestOfHttpRedirects extends UnitTestCase
                 'createHttpRequest',
                 $this->createRedirect('third', 'four.html'));
         $agent->expectCallCount('createHttpRequest', 3);
-        $agent->__construct();
+        $agent->__constructor();
 
         $agent->setMaximumRedirects(2);
         $response = $agent->fetchResponse(new SimpleUrl('one.html'), new SimpleGetEncoding());
@@ -299,7 +299,7 @@ class TestOfHttpRedirects extends UnitTestCase
                 'createHttpRequest',
                 $this->createRedirect('third', 'four.html'));
         $agent->expectCallCount('createHttpRequest', 2);
-        $agent->__construct();
+        $agent->__constructor();
 
         $agent->setMaximumRedirects(2);
         $response = $agent->fetchResponse(new SimpleUrl('one.html'), new SimpleGetEncoding());
@@ -320,7 +320,7 @@ class TestOfHttpRedirects extends UnitTestCase
                 $this->createRedirect('second', 'three.html'));
         $agent->expectAt(1, 'createHttpRequest', array('*', new IsAExpectation('SimpleGetEncoding')));
         $agent->expectCallCount('createHttpRequest', 2);
-        $agent->__construct();
+        $agent->__constructor();
         $agent->setMaximumRedirects(1);
         $response = $agent->fetchResponse(new SimpleUrl('one.html'), new SimplePostEncoding());
     }
@@ -345,7 +345,7 @@ class TestOfBadHosts extends UnitTestCase
         $request = $this->createSimulatedBadHost();
         $agent   = new MockRequestUserAgent();
         $agent->returnsByReference('createHttpRequest', $request);
-        $agent->__construct();
+        $agent->__constructor();
         $response = $agent->fetchResponse(
                 new SimpleUrl('http://this.host/this/path/page.html'),
                 new SimpleGetEncoding());
@@ -369,7 +369,7 @@ class TestOfAuthorisation extends UnitTestCase
 
         $agent = new MockRequestUserAgent();
         $agent->returns('createHttpRequest', $request);
-        $agent->__construct();
+        $agent->__constructor();
         $response = $agent->fetchResponse(
                 new SimpleUrl('http://test:secret@this.host'),
                 new SimpleGetEncoding());


### PR DESCRIPTION
If anyone has an idea about why PHPUnitTestCase::assertSame() only works with by-reference arguments, even for objects, please enlighten me. UnitTestCase::assertSame() does not require by-reference arguments to work.

Currently, 7.3 and 7.2 receive Active Support, while 7.1 receives Security Support. PHP <= 7.0 should no longer be used by anyone.
[PHP: Supported Versions](https://www.php.net/supported-versions.php)

HHVM will drop PHP support in November 2019. Since the tests already haven't even been run on HHVM for a long time now I suggest dropping HHVM now.
[HHVM 3.30](https://hhvm.com/blog/2018/12/17/hhvm-3.30.html)