### PR TITLE
Should parse first base and title tags only

### DIFF
--- a/src/php_parser.php
+++ b/src/php_parser.php
@@ -941,9 +941,9 @@ class SimplePhpPageBuilder
     {
         if ('a' === $tag->getTagName()) {
             $this->page->addLink($tag);
-        } elseif ('base' === $tag->getTagName()) {
+        } elseif (('base' === $tag->getTagName()) && ($this->page->getBase() === false)) {
             $this->page->setBase($tag->getAttribute('href'));
-        } elseif ('title' === $tag->getTagName()) {
+        } elseif (('title' === $tag->getTagName()) && ($this->page->getTitle() === false)) {
             $this->page->setTitle($tag);
         } elseif ($this->isFormElement($tag->getTagName())) {
             for ($i = 0; $i < count($this->open_forms); ++$i) {


### PR DESCRIPTION
It is important to only parse the first `title` tag. One might think an HTML file can only contain a single tag, but actually embedded SVG (within an `svg` tag) may provide its own title, and we do not want to be capturing that.