### PR TITLE
Fix printf escaping problem

### DIFF
--- a/src/test_case.php
+++ b/src/test_case.php
@@ -307,7 +307,7 @@ class SimpleTestCase
      */
     public function assert($expectation, $compare, $message = '%s')
     {
-        $message = $this->escapePercentageSignsExceptFirst($message);
+        $message = $this->escapeIncidentalPrintfSyntax($message);
 
         if ($expectation->test($compare)) {
             return $this->pass(
@@ -321,7 +321,8 @@ class SimpleTestCase
     }
 
     /**
-     * Escapes all percentage signs, except the first.
+     * Escapes all percentage signs so *printf functions don't do any special processing...
+     * ... except for the first one if it forms %s, which is used to reference the auto-generated assert message
      *
      * Get the position of the first percentage sign.
      * Skip over escaping, if none is found.
@@ -329,17 +330,15 @@ class SimpleTestCase
      * Then concat unescaped first part and escaped part.
      *
      * @param string $string
-     *
      * @return string
      */
-    protected function escapePercentageSignsExceptFirst($string)
+    protected function escapeIncidentalPrintfSyntax($string)
     {
-        $pos = strpos($string, '%');
-        if (false !== $pos) {
-            return substr($string, 0, $pos + 1).str_replace('%', '%%', substr($string, $pos + 1));
+        $pos = strpos($string, '%s');
+        if($pos !== false) {
+            return substr($string, 0, $pos + 2) . str_replace('%', '%%', substr($string, $pos + 2));
         }
-
-        return $string;
+        return str_replace('%', '%%', $string);
     }
 
     /**

--- a/test/unit_tester_test.php
+++ b/test/unit_tester_test.php
@@ -94,10 +94,31 @@ class TestOfUnitTester extends UnitTestCase
         $this->assertCopy($a, $b);
     }
 
-    public function testEscapePercentageSignsExceptFirst()
+    public function testEscapeIncidentalPrintfSyntax()
     {
-        $a = 'http://www.domain.com/some%20long%%20name.html';
-        $b = $this->escapePercentageSignsExceptFirst('http://www.domain.com/some%20long%20name.html');
+        // Incidentals are escaped
+        $a = 'http://www.domain.com/some%%20long%%20name.html';
+        $b = $this->escapeIncidentalPrintfSyntax('http://www.domain.com/some%20long%20name.html');
+        $this->assertEqual($a, $b);
+
+        // Non-incidental is not escaped
+        $a = 'SimpleTest error: %s :-)';
+        $b = $this->escapeIncidentalPrintfSyntax('SimpleTest error: %s :-)');
+        $this->assertEqual($a, $b);
+
+        // Non-incidental is not escaped (end position edge case)
+        $a = 'SimpleTest error: %s';
+        $b = $this->escapeIncidentalPrintfSyntax('SimpleTest error: %s');
+        $this->assertEqual($a, $b);
+
+        // Non-incidental is not escaped (start position edge case)
+        $a = '%s (SimpleTest error)';
+        $b = $this->escapeIncidentalPrintfSyntax('%s (SimpleTest error)');
+        $this->assertEqual($a, $b);
+
+        // Correct escaping/preservation for both non-incidetal and incidentals
+        $a = '%s (%%SimpleTest error%%)';
+        $b = $this->escapeIncidentalPrintfSyntax('%s (%SimpleTest error%)');
         $this->assertEqual($a, $b);
     }
 }


### PR DESCRIPTION
The sprintf escaping in assert is unworkable in some practical situations. In fact, there's a unit test showing it's impractical for URLs.
Specifically, if a URL has multiple percentages, to embed the URL in an assert string you'd have to escape the first % but not subsequent ones, to avoid it being double escaped and thus interpreted by sprintf and resulting in an error message about insufficient parameters. That's intense and messy.

As far as I can tell the only case for printf escaping being preserved is for '%s', as used by the default assert string, or as used to embed the default assert output into a custom string.

Nothing other than '%s' is needed, and only the first is needed.

Therefore I've rewritten the code, and tests, to escape based on our actual requirements. This is unlikely to cause any kind of conflict with custom assert messages, and if it does then that conflict already existed.

I could see people might have hacked their way around the problem I'm fixing here already and my fix may conflict with that hack, but I think it's best to let them fix their code now.