### PR TITLE
Fix partial mock namespaces.

### DIFF
--- a/src/mock_objects.php
+++ b/src/mock_objects.php
@@ -1507,7 +1507,7 @@ class MockGenerator
         $code .= "\n";
 
         $code .= "    function __construct() {\n";
-        $code .= '        $this->mock = new '.$this->mock_base."();\n";
+        $code .= '        $this->mock = new \\'.$this->mock_base."();\n";
         $code .= "        \$this->mock->disableExpectationNameChecks();\n";
         $code .= "    }\n";
         $code .= $this->createCodeForConstructor();

--- a/src/mock_objects.php
+++ b/src/mock_objects.php
@@ -1495,7 +1495,13 @@ class MockGenerator
      */
     protected function extendClassCode($methods)
     {
-        $code = 'class '.$this->mock_class.' extends '.$this->class." {\n";
+        $code = '';
+
+        if (!empty($this->namespace)) {
+            $code .= 'namespace '.$this->namespace.";\n";
+        }
+
+        $code .= 'class '.$this->mock_class.' extends '.$this->class." {\n";
         $code .= "    protected \$mock;\n";
         $code .= $this->addMethodList($methods);
         $code .= "\n";

--- a/test/mock_objects_test.php
+++ b/test/mock_objects_test.php
@@ -3,6 +3,7 @@
 require_once __DIR__.'/../src/autorun.php';
 require_once __DIR__.'/../src/expectation.php';
 require_once __DIR__.'/../src/mock_objects.php';
+require_once __DIR__.'/support/dummy_namespace.php';
 
 class TestOfAnythingExpectation extends UnitTestCase
 {
@@ -1161,5 +1162,17 @@ class TestOfProtectedMethodPartialMocks extends UnitTestCase
         $object = new TestDummyWithProtected();
         $object->returnsByValue('aProtectedMethod', false);
         $this->assertFalse($object->aMethodCallsProtected());
+    }
+}
+
+Mock::generate('DummyNS\DummyWithNamespace', 'TestFullDummyWithNamespace');
+Mock::generatePartial('DummyNS\DummyWithNamespace', 'TestPartialDummyWithNamespace', ['aMethod']);
+
+class TestOfNamespacedPartialMocks extends UnitTestCase
+{
+    public function testsMockExistsUnderNamespace()
+    {
+        $this->assertTrue(class_exists('DummyNS\TestFullDummyWithNamespace'));
+        $this->assertTrue(class_exists('DummyNS\TestPartialDummyWithNamespace'));
     }
 }

--- a/test/support/dummy_namespace.php
+++ b/test/support/dummy_namespace.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace DummyNS;
+
+class DummyWithNamespace
+{
+    public function aMethod() {}
+}


### PR DESCRIPTION
Partially mocking a namepaced class throws an error, as it attempts to extend just the base class rather than the full class name.

In this fix I've opted to mimic the behaviour of full mocks; placing the new partial mock under the same namespace as the mock subject.