### PR TITLE
Fix addition of new methods to mocks.

### DIFF
--- a/src/mock_objects.php
+++ b/src/mock_objects.php
@@ -1508,8 +1508,8 @@ class MockGenerator
         $code .= $this->chainMockReturns();
         $code .= $this->chainMockExpectations();
         $code .= $this->chainThrowMethods();
-        $code .= $this->createCodeForOverridenMethods(array_intersect($methods, $this->reflection->getMethods()));
-        $code .= $this->createCodeForNewMethod($methods);
+        $code .= $this->createCodeForOverridenMethods(array_intersect($methods, $this->reflection->getAllMethods()));
+        $code .= $this->createCodeForNewMethod(array_diff($methods, $this->reflection->getAllMethods()));
         $code .= "}\n";
 
         return $code;

--- a/src/mock_objects.php
+++ b/src/mock_objects.php
@@ -1508,7 +1508,8 @@ class MockGenerator
         $code .= $this->chainMockReturns();
         $code .= $this->chainMockExpectations();
         $code .= $this->chainThrowMethods();
-        $code .= $this->createCodeForOverridenMethods($methods);
+        $code .= $this->createCodeForOverridenMethods(array_intersect($methods, $this->reflection->getMethods()));
+        $code .= $this->createCodeForNewMethod($methods);
         $code .= "}\n";
 
         return $code;
@@ -1569,7 +1570,7 @@ class MockGenerator
             if (in_array($method, $mock_reflection->getMethods())) {
                 continue;
             }
-            $code .= '    '.$this->reflection->getSignature($method)." {\n";
+            $code .= "    public function {$method}() {\n";
             $code .= "        return \$this->mock->invoke(\"$method\", func_get_args());\n";
             $code .= "    }\n";
         }

--- a/src/reflection.php
+++ b/src/reflection.php
@@ -87,6 +87,21 @@ class SimpleReflection
     }
 
     /**
+     * Gets the list of all methods in a class or interface, including
+     * non-visible.
+     *
+     * @returns array              List of method names.
+     */
+    public function getAllMethods()
+    {
+        $reflection = new ReflectionClass($this->interface);
+
+        return array_map(function($method) {
+            return $method->getName();
+        }, $reflection->getMethods());
+    }
+
+    /**
      * Gets the list of interfaces from a class.
      * If the class name is actually an interface then just that interface is returned.
      *

--- a/test/mock_objects_test.php
+++ b/test/mock_objects_test.php
@@ -246,6 +246,7 @@ class Dummy
 Mock::generate('Dummy');
 Mock::generate('Dummy', 'AnotherMockDummy');
 Mock::generate('Dummy', 'MockDummyWithExtraMethods', ['extraMethod']);
+Mock::generatePartial('Dummy', 'MockPartialDummyWithExtraMethods', ['extraMethod']);
 
 class TestOfConstructorCreation extends UnitTestCase
 {
@@ -269,6 +270,12 @@ class TestOfConstructorCreation extends UnitTestCase
         $mock = new AnotherMockDummy();
         $this->assertTrue(method_exists($mock, '__constructor'));
     }
+
+    public function testExtendingWithExtraMethod()
+    {
+        $mock = new MockPartialDummyWithExtraMethods();
+        $this->assertTrue(method_exists($mock, '__constructor'));
+    }
 }
 
 class TestOfMockGeneration extends UnitTestCase
@@ -290,6 +297,12 @@ class TestOfMockGeneration extends UnitTestCase
     {
         $mock = new AnotherMockDummy();
         $this->assertTrue(method_exists($mock, 'aMethod'));
+    }
+
+    public function testExtendingWithExtraMethod()
+    {
+        $mock = new MockPartialDummyWithExtraMethods();
+        $this->assertTrue(method_exists($mock, 'extraMethod'));
     }
 }
 

--- a/test/mock_objects_test.php
+++ b/test/mock_objects_test.php
@@ -242,6 +242,16 @@ class Dummy
     {
         return true;
     }
+
+    protected function aProtectedMethod()
+    {
+        return true;
+    }
+
+    private function aPrivateMethod()
+    {
+        return true;
+    }
 }
 Mock::generate('Dummy');
 Mock::generate('Dummy', 'AnotherMockDummy');
@@ -293,6 +303,18 @@ class TestOfMockGeneration extends UnitTestCase
         $this->assertTrue(method_exists($mock, 'extraMethod'));
     }
 
+    public function testCloningWithProtectedMethod()
+    {
+        $mock = new MockDummyWithExtraMethods();
+        $this->assertTrue(method_exists($mock, 'aProtectedMethod'));
+    }
+
+    public function testCloningWithPrivateMethod()
+    {
+        $mock = new MockDummyWithExtraMethods();
+        $this->assertTrue(method_exists($mock, 'aPrivateMethod'));
+    }
+
     public function testCloningWithChosenClassName()
     {
         $mock = new AnotherMockDummy();
@@ -303,6 +325,18 @@ class TestOfMockGeneration extends UnitTestCase
     {
         $mock = new MockPartialDummyWithExtraMethods();
         $this->assertTrue(method_exists($mock, 'extraMethod'));
+    }
+
+    public function testExtendingWithProtectedMethod()
+    {
+        $mock = new MockPartialDummyWithExtraMethods();
+        $this->assertTrue(method_exists($mock, 'aProtectedMethod'));
+    }
+
+    public function testExtendingWithPrivateMethod()
+    {
+        $mock = new MockPartialDummyWithExtraMethods();
+        $this->assertTrue(method_exists($mock, 'aPrivateMethod'));
     }
 }
 


### PR DESCRIPTION
In 1.1.0, you could add new methods when generating a mock. This was useful when testing a class you've yet to write, and also for dealing with magic methods.

Code comments suggest this feature is still supported, but the code errors when attempting to build the signature from the reflection, since the method doesn't exist.

This fix adds support for generating new, arg-less methods to full and partial mocks.