### PR TITLE
Remove stray echo.

### DIFF
--- a/src/test_case.php
+++ b/src/test_case.php
@@ -401,7 +401,6 @@ class SimpleFileLoader
     {
         $existing_classes = get_declared_classes();
         $existing_globals = get_defined_vars();
-        echo $test_file.PHP_EOL;
         include_once $test_file;
         $new_globals = get_defined_vars();
         $this->makeFileVariablesGlobal($existing_globals, $new_globals);


### PR DESCRIPTION
PHP 7 now errors when calling `ini_set` after headers have already been sent. This `echo` statement results in a write that in turn triggers the error scenario.

It looks like the echo was possibly committed by mistake, as the other changes in b7e749a981b31bf142337281fc658143bdcc5453 seem unrelated. Removing the echo doesn't appear to affect tests in any negative way.