### PR TITLE
Allow installing from PHP 8 project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         }
     ],
     "require": {
-        "php": "^7.1"
+        "php": ">=7.1"
     },
     "require-dev" : {
         "ext-dom": "*",


### PR DESCRIPTION
Change from requiring php >=7.1 <8.0.0 to allowing php 7.1 and above, including 8.