### PR TITLE
remove test of is_real() which was deprecated in 7.4

### DIFF
--- a/test/expectation_test.php
+++ b/test/expectation_test.php
@@ -310,13 +310,6 @@ class TestOfIsA extends UnitTestCase
         $this->assertFalse($expectation->test(5));
     }
 
-    public function testReal()
-    {
-        $expectation = new IsAExpectation('real');
-        $this->assertTrue($expectation->test(5.0));
-        $this->assertFalse($expectation->test(5));
-    }
-
     public function testInteger()
     {
         $expectation = new IsAExpectation('integer');


### PR DESCRIPTION
Aims to make 7.4 tests pass.
It was just an alias to is_float() all along.