### PR TITLE
pull latest changes from ezyang/simpletest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         }
     ],
     "require": {
-        "php": "^5.4 || ^7.0"
+        "php": "^5.4 || ^7.0 || ^8.0"
     },
     "replace": {
         "vierbergenlars/simpletest": "self.version",

--- a/dumper.php
+++ b/dumper.php
@@ -126,7 +126,7 @@ class SimpleDumper
             return $value;
         }
         $position = min($position, $length);
-        $start    = ($size/2 > $position ? 0 : $position - $size/2);
+        $start    = (int)($size/2 > $position ? 0 : $position - $size/2);
         if ($start + $size > $length) {
             $start = $length - $size;
         }

--- a/errors.php
+++ b/errors.php
@@ -208,7 +208,6 @@ class SimpleErrorQueue
             E_USER_ERROR      => 'E_USER_ERROR',
             E_USER_WARNING    => 'E_USER_WARNING',
             E_USER_NOTICE     => 'E_USER_NOTICE',
-            E_STRICT          => 'E_STRICT',
             E_ALL             => 'E_ALL'
         );
 

--- a/expectation.php
+++ b/expectation.php
@@ -465,6 +465,7 @@ class OutsideMarginExpectation extends WithinMarginExpectation
 class ReferenceExpectation
 {
     private $value;
+    private $message;
 
     /**
      * Sets the reference value to compare against.

--- a/mock_objects.php
+++ b/mock_objects.php
@@ -411,6 +411,8 @@ class SimpleCallSchedule
     private $always;
     private $at;
 
+    public $expected_args;
+
     /**
      * Sets up an empty response schedule. Creates an empty call map.
      */

--- a/mock_objects.php
+++ b/mock_objects.php
@@ -1199,20 +1199,15 @@ class SimpleMock
     }
 
     /**
-     * Our mock has to be able to return anything, including variable references.
-     * To allow for these mixed returns we have to disable the E_STRICT warnings,
-     * while the method calls are emulated.
+     * Does nothing now.
      */
     private function disableEStrict()
     {
-        $was = error_reporting();
-        error_reporting($was & ~E_STRICT);
-
-        return $was;
+        return error_reporting();
     }
 
     /**
-     * Restores the E_STRICT level if it was previously set.
+     * Does nothing now.
      *
      * @param int $was Previous error reporting level.
      */

--- a/mock_objects.php
+++ b/mock_objects.php
@@ -751,7 +751,7 @@ class SimpleMock
     {
         if ($this->is_strict && ! method_exists($this, $method)) {
             trigger_error(
-                "Cannot $task as no ${method}() in class " . get_class($this),
+                "Cannot $task as no {$method}() in class " . get_class($this),
                 E_USER_ERROR
             );
         }

--- a/reflection_php5.php
+++ b/reflection_php5.php
@@ -359,11 +359,23 @@ class SimpleReflection
         $signatures = array();
         foreach ($method->getParameters() as $parameter) {
             $signature = '';
-            $type      = $parameter->getClass();
-            if (is_null($type) && version_compare(phpversion(), '5.1.0', '>=') && $parameter->isArray()) {
-                $signature .= 'array ';
-            } elseif (!is_null($type)) {
-                $signature .= $type->getName() . ' ';
+            if (version_compare(phpversion(), '8.0.0', '>=')) {
+                $type = $parameter->getType() && ! $parameter->getType()->isBuiltin()
+                    ? new ReflectionClass($parameter->getType()->getName())
+                    : null;
+
+                if ($type && $type->getName() === 'array') {
+                    $signature .= 'array ';
+                } elseif ($type) {
+                    $signature .= $type->getName() . ' ';
+                }
+            } else {
+                $type = $parameter->getClass();
+                if (is_null($type) && version_compare(phpversion(), '5.1.0', '>=') && $parameter->isArray()) {
+                    $signature .= 'array ';
+                } elseif (!is_null($type)) {
+                    $signature .= $type->getName() . ' ';
+                }
             }
             if ($parameter->isPassedByReference()) {
                 $signature .= '&';

--- a/test/support/spl_examples.php
+++ b/test/support/spl_examples.php
@@ -2,22 +2,27 @@
 
 class IteratorImplementation implements Iterator
 {
+    #[\ReturnTypeWillChange]
     public function current()
     {
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
     }
 
+    #[\ReturnTypeWillChange]
     public function valid()
     {
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
     }
@@ -25,6 +30,7 @@ class IteratorImplementation implements Iterator
 
 class IteratorAggregateImplementation implements IteratorAggregate
 {
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
     }


### PR DESCRIPTION
This PR is for cherry picking. It needs a manual merge, because

- of file and method name changes in upstream simpletest
- additional methods on mock_objects in downstream ezyang/simpletest need to be transfered 
- the changes to lines containing trigger_error can be dropped, because upstream simpletest uses `sprintf()` for building the error messages