### PR TITLE
Making simpletest compatible with PHP 8.4

### DIFF
--- a/extensions/selenium.php
+++ b/extensions/selenium.php
@@ -25,12 +25,12 @@ class SeleniumTestCase extends UnitTestCase
         parent::__construct($name);
 
         if (empty($this->browser)) {
-            trigger_error('browser property must be set in ' . get_class($this));
+            simpletest_trigger_error('browser property must be set in ' . get_class($this));
             exit;
         }
 
         if (empty($this->browserUrl)) {
-            trigger_error('browserUrl property must be set in ' . get_class($this));
+            simpletest_trigger_error('browserUrl property must be set in ' . get_class($this));
             exit;
         }
     }

--- a/src/detached.php
+++ b/src/detached.php
@@ -53,7 +53,7 @@ class DetachedTestCase
         $shell->execute($this->command);
         $parser = $this->createParser($reporter);
         if (!$parser->parse($shell->getOutput())) {
-            trigger_error('Cannot parse incoming XML from ['.$this->command.']');
+            simpletest_trigger_error('Cannot parse incoming XML from ['.$this->command.']');
 
             return false;
         }
@@ -74,7 +74,7 @@ class DetachedTestCase
             $reporter = new SimpleReporter();
             $parser = $this->createParser($reporter);
             if (!$parser->parse($shell->getOutput())) {
-                trigger_error('Cannot parse incoming XML from ['.$this->dry_command.']');
+                simpletest_trigger_error('Cannot parse incoming XML from ['.$this->dry_command.']');
 
                 return false;
             }

--- a/src/errors.php
+++ b/src/errors.php
@@ -213,12 +213,15 @@ class SimpleErrorQueue
             E_USER_ERROR => 'E_USER_ERROR',
             E_USER_WARNING => 'E_USER_WARNING',
             E_USER_NOTICE => 'E_USER_NOTICE',
-            E_STRICT => 'E_STRICT',
             E_RECOVERABLE_ERROR => 'E_RECOVERABLE_ERROR',   // PHP 5.2
             E_DEPRECATED => 'E_DEPRECATED',          // PHP 5.3
             E_USER_DEPRECATED => 'E_USER_DEPRECATED',     // PHP 5.3
             E_ALL => 'E_ALL',
         ];
+
+        if (PHP_VERSION_ID < 80400) {
+            $map[E_STRICT] = 'E_STRICT';    // deprecated since PHP 8.4
+        }
 
         return $map[$severity];
     }

--- a/src/errors.php
+++ b/src/errors.php
@@ -210,7 +210,6 @@ class SimpleErrorQueue
             E_CORE_WARNING => 'E_CORE_WARNING',
             E_COMPILE_ERROR => 'E_COMPILE_ERROR',
             E_COMPILE_WARNING => 'E_COMPILE_WARNING',
-            E_USER_ERROR => 'E_USER_ERROR',
             E_USER_WARNING => 'E_USER_WARNING',
             E_USER_NOTICE => 'E_USER_NOTICE',
             E_RECOVERABLE_ERROR => 'E_RECOVERABLE_ERROR',   // PHP 5.2
@@ -219,8 +218,10 @@ class SimpleErrorQueue
             E_ALL => 'E_ALL',
         ];
 
+        // deprecated since PHP 8.4
         if (PHP_VERSION_ID < 80400) {
-            $map[E_STRICT] = 'E_STRICT';    // deprecated since PHP 8.4
+            $map[E_USER_ERROR]  = 'E_USER_ERROR';
+            $map[E_STRICT]      = 'E_STRICT';
         }
 
         return $map[$severity];
@@ -251,4 +252,12 @@ function SimpleTestErrorHandler($severity, $message, $file = null, $line = null,
     }
 
     return true;
+}
+
+function simpletest_trigger_error(string $message, int $errorLevel)
+{
+    if (PHP_VERSION_ID >= 80400 && E_USER_ERROR === $errorLevel) {
+        throw new ErrorException($message, $errorLevel);
+    }
+    trigger_error($message, $errorLevel);
 }

--- a/src/errors.php
+++ b/src/errors.php
@@ -254,7 +254,7 @@ function SimpleTestErrorHandler($severity, $message, $file = null, $line = null,
     return true;
 }
 
-function simpletest_trigger_error(string $message, int $errorLevel)
+function simpletest_trigger_error(string $message, int $errorLevel = E_USER_NOTICE)
 {
     if (PHP_VERSION_ID >= 80400 && E_USER_ERROR === $errorLevel) {
         throw new ErrorException($message, $errorLevel);

--- a/src/mock_objects.php
+++ b/src/mock_objects.php
@@ -1303,7 +1303,9 @@ class SimpleMock
     private function disableEStrict()
     {
         $was = error_reporting();
-        error_reporting($was & ~E_STRICT);
+        if (PHP_VERSION_ID < 80400) {
+            error_reporting($was & ~E_STRICT);
+        }
 
         return $was;
     }

--- a/src/mock_objects.php
+++ b/src/mock_objects.php
@@ -692,7 +692,7 @@ class SimpleErrorThrower
      */
     public function act()
     {
-        trigger_error($this->error, $this->severity);
+        simpletest_trigger_error($this->error, $this->severity);
 
         return;
     }
@@ -771,7 +771,7 @@ class SimpleMock
     {
         if (!is_array($args)) {
             $errormsg = sprintf('Cannot %s. Parameter %s is not an array.', $task, $args);
-            trigger_error($errormsg, E_USER_ERROR);
+            simpletest_trigger_error($errormsg, E_USER_ERROR);
 
             return false;
         }
@@ -791,7 +791,7 @@ class SimpleMock
     {
         if ($this->is_strict && !method_exists($this, $method)) {
             $errormsg = sprintf('Cannot %s. Method %s() not in class %s.', $task, $method, get_class($this));
-            trigger_error($errormsg, E_USER_ERROR);
+            simpletest_trigger_error($errormsg, E_USER_ERROR);
 
             return false;
         }
@@ -1334,7 +1334,7 @@ class Mock
      */
     public function __construct()
     {
-        trigger_error('Mock factory methods are static.');
+        simpletest_trigger_error('Mock factory methods are static.');
     }
 
     /**
@@ -1484,7 +1484,7 @@ class MockGenerator
         }
         $mock_reflection = new SimpleReflection($this->mock_class);
         if ($mock_reflection->classExistsWithoutAutoload()) {
-            trigger_error('Partial mock class ['.$this->mock_class.'] already exists');
+            simpletest_trigger_error('Partial mock class ['.$this->mock_class.'] already exists');
 
             return false;
         }

--- a/src/reflection.php
+++ b/src/reflection.php
@@ -457,6 +457,18 @@ class SimpleReflection
             $typeHint = '\\'.$typeHint;
         }
 
+        // Since PHP 8.4 implicitly marking parameter as nullable is deprecated,
+        // the explicit nullable type must be used instead
+        if (PHP_VERSION_ID >= 80400
+            &&
+            $parameter->isOptional()
+            &&
+            $typeHint !== 'mixed'
+            &&
+            strpos($typeHint, "|") === false && strpos($typeHint, "&") === false) {
+            $typeHint = '?' . $typeHint;
+        }
+
         return $typeHint .= ' ';
     }
 }

--- a/src/remote.php
+++ b/src/remote.php
@@ -54,13 +54,13 @@ class RemoteTestCase
         $browser = $this->createBrowser();
         $xml = $browser->get($this->url);
         if (!$xml) {
-            trigger_error('Cannot read remote test URL ['.$this->url.']');
+            simpletest_trigger_error('Cannot read remote test URL ['.$this->url.']');
 
             return false;
         }
         $parser = $this->createParser($reporter);
         if (!$parser->parse($xml)) {
-            trigger_error('Cannot parse incoming XML from ['.$this->url.']');
+            simpletest_trigger_error('Cannot parse incoming XML from ['.$this->url.']');
 
             return false;
         }
@@ -101,14 +101,14 @@ class RemoteTestCase
             $browser = $this->createBrowser();
             $xml = $browser->get($this->dry_url);
             if (!$xml) {
-                trigger_error('Cannot read remote test URL ['.$this->dry_url.']');
+                simpletest_trigger_error('Cannot read remote test URL ['.$this->dry_url.']');
 
                 return false;
             }
             $reporter = new SimpleReporter();
             $parser = $this->createParser($reporter);
             if (!$parser->parse($xml)) {
-                trigger_error('Cannot parse incoming XML from ['.$this->dry_url.']');
+                simpletest_trigger_error('Cannot parse incoming XML from ['.$this->dry_url.']');
 
                 return false;
             }

--- a/src/test_case.php
+++ b/src/test_case.php
@@ -234,7 +234,7 @@ class SimpleTestCase
     public function pass($message = 'Pass')
     {
         if (!isset($this->reporter)) {
-            trigger_error('Can only make assertions within test methods');
+            simpletest_trigger_error('Can only make assertions within test methods');
         }
         $this->reporter->paintPass($message.$this->getAssertionLine());
 
@@ -249,7 +249,7 @@ class SimpleTestCase
     public function fail($message = 'Fail')
     {
         if (!isset($this->reporter)) {
-            trigger_error('Can only make assertions within test methods');
+            simpletest_trigger_error('Can only make assertions within test methods');
         }
         $this->reporter->paintFail($message.$this->getAssertionLine());
 
@@ -267,7 +267,7 @@ class SimpleTestCase
     public function error($severity, $message, $file, $line)
     {
         if (!isset($this->reporter)) {
-            trigger_error('Can only make assertions within test methods');
+            simpletest_trigger_error('Can only make assertions within test methods');
         }
         $this->reporter->paintError("Unexpected PHP Error [$message] severity [$severity] in [$file line $line]");
     }
@@ -291,7 +291,7 @@ class SimpleTestCase
     public function signal($type, $payload)
     {
         if (!isset($this->reporter)) {
-            trigger_error('Can only make assertions within test methods');
+            simpletest_trigger_error('Can only make assertions within test methods');
         }
         $this->reporter->paintSignal($type, $payload);
     }

--- a/src/web_tester.php
+++ b/src/web_tester.php
@@ -716,7 +716,7 @@ class WebTestCase extends SimpleTestCase
     public function setMaximumRedirects($max)
     {
         if (!$this->browser) {
-            trigger_error(
+            simpletest_trigger_error(
                 'Can only set maximum redirects in a test method, setUp() or tearDown()'
             );
         }

--- a/src/xml.php
+++ b/src/xml.php
@@ -560,7 +560,7 @@ class SimpleTestXmlParser
                 xml_get_current_column_number($this->expat),
                 xml_get_current_byte_index($this->expat)
             );
-            trigger_error($message);
+            simpletest_trigger_error($message);
 
             return false;
         }

--- a/src/xml.php
+++ b/src/xml.php
@@ -576,10 +576,9 @@ class SimpleTestXmlParser
     protected function createParser()
     {
         $expat = xml_parser_create();
-        xml_set_object($expat, $this);
-        xml_set_element_handler($expat, 'startElement', 'endElement');
-        xml_set_character_data_handler($expat, 'addContent');
-        xml_set_default_handler($expat, 'defaultContent');
+        xml_set_element_handler($expat, [$this, 'startElement'], [$this, 'endElement']);
+        xml_set_character_data_handler($expat, [$this, 'addContent']);
+        xml_set_default_handler($expat, [$this, 'defaultContent']);
 
         return $expat;
     }

--- a/tests/errors_test.php
+++ b/tests/errors_test.php
@@ -67,33 +67,33 @@ class TestOfErrorTrap extends UnitTestCase
     public function testErrorsAreSwallowedByMatchingExpectation()
     {
         $this->expectError('Ouch!');
-        trigger_error('Ouch!');
+        simpletest_trigger_error('Ouch!');
     }
 
     public function testErrorsAreSwallowedInOrder()
     {
         $this->expectError('a');
         $this->expectError('b');
-        trigger_error('a');
-        trigger_error('b');
+        simpletest_trigger_error('a');
+        simpletest_trigger_error('b');
     }
 
     public function testAnyErrorCanBeSwallowed()
     {
         $this->expectError();
-        trigger_error('Ouch!');
+        simpletest_trigger_error('Ouch!');
     }
 
     public function testErrorCanBeSwallowedByPatternMatching()
     {
         $this->expectError(new PatternExpectation('/ouch/i'));
-        trigger_error('Ouch!');
+        simpletest_trigger_error('Ouch!');
     }
 
     public function testErrorWithPercentsPassesWithNoSprintfError()
     {
         $this->expectError('%');
-        trigger_error('%');
+        simpletest_trigger_error('%');
     }
 }
 
@@ -115,46 +115,50 @@ class TestOfErrors extends UnitTestCase
     {
         error_reporting(E_ALL);
         $this->expectError('Ouch!');
-        trigger_error('Ouch!');
+        simpletest_trigger_error('Ouch!');
     }
 
     public function testNoticeWhenReported()
     {
         error_reporting(E_ALL);
         $this->expectError('Ouch!');
-        trigger_error('Ouch!', E_USER_NOTICE);
+        simpletest_trigger_error('Ouch!', E_USER_NOTICE);
     }
 
     public function testWarningWhenReported()
     {
         error_reporting(E_ALL);
         $this->expectError('Ouch!');
-        trigger_error('Ouch!', E_USER_WARNING);
+        simpletest_trigger_error('Ouch!', E_USER_WARNING);
     }
 
     public function testErrorWhenReported()
     {
         error_reporting(E_ALL);
-        $this->expectError('Ouch!');
-        trigger_error('Ouch!', E_USER_ERROR);
+        if (PHP_VERSION_ID < 80400) {
+            $this->expectError('Ouch!');
+        } else {
+            $this->expectException(ErrorException::class, 'Ouch!');
+        }
+        simpletest_trigger_error('Ouch!', E_USER_ERROR);
     }
 
     public function testNoNoticeWhenNotReported()
     {
         error_reporting(0);
-        trigger_error('Ouch!', E_USER_NOTICE);
+        simpletest_trigger_error('Ouch!', E_USER_NOTICE);
     }
 
     public function testNoWarningWhenNotReported()
     {
         error_reporting(0);
-        trigger_error('Ouch!', E_USER_WARNING);
+        simpletest_trigger_error('Ouch!', E_USER_WARNING);
     }
 
     public function testNoticeSuppressedWhenReported()
     {
         error_reporting(E_ALL);
-        @trigger_error('Ouch!', E_USER_NOTICE);
+        @simpletest_trigger_error('Ouch!', E_USER_NOTICE);
     }
 
     public function testWarningSuppressedWhenReported()
@@ -166,7 +170,7 @@ class TestOfErrors extends UnitTestCase
     public function testErrorWithPercentsReportedWithNoSprintfError()
     {
         $this->expectError('%');
-        trigger_error('%');
+        simpletest_trigger_error('%');
     }
 }
 
@@ -182,7 +186,7 @@ class TestOfNotEnoughErrors extends UnitTestCase
     public function testExpectTwoErrorsThrowOne()
     {
         $this->expectError('Error 1');
-        trigger_error('Error 1');
+        simpletest_trigger_error('Error 1');
         $this->expectError('Error 2');
     }
 }
@@ -199,8 +203,8 @@ class TestOfLeftOverErrors extends UnitTestCase
     public function testExpectOneErrorGetTwo()
     {
         $this->expectError('Error 1');
-        trigger_error('Error 1');
-        trigger_error('Error 2');
+        simpletest_trigger_error('Error 1');
+        simpletest_trigger_error('Error 2');
     }
 }
 

--- a/tests/interfaces_test.php
+++ b/tests/interfaces_test.php
@@ -34,7 +34,7 @@ class TestOfMockInterfaces extends UnitTestCase
         try {
             $mock->anotherMethod();
         } catch (Error $e) {
-            trigger_error($e->getMessage());
+            simpletest_trigger_error($e->getMessage());
         }
     }
 

--- a/tests/mock_objects_test.php
+++ b/tests/mock_objects_test.php
@@ -798,7 +798,11 @@ class TestOfMockExpectations extends UnitTestCase
     public function testNonArrayForExpectedParametersGivesError()
     {
         $mock = new MockDummyWithInjectedTestCase();
-        $this->expectError(new PatternExpectation('/foo is not an array/i'));
+        if (PHP_VERSION_ID < 80400) {
+            $this->expectError(new PatternExpectation('/foo is not an array/i'));
+        } else {
+            $this->expectException(ErrorException::class, 'Ouch!');
+        }
         $mock->expect('aMethod', 'foo');
         $mock->aMethod();
         $mock->mock->atTestEnd('testSomething', $this->test);
@@ -981,7 +985,12 @@ class TestOfThrowingErrorsFromMocks extends UnitTestCase
     {
         $mock = new MockDummy();
         $mock->errorOn('aMethod', 'Ouch!');
-        $this->expectError('Ouch!');
+
+        if (PHP_VERSION_ID < 80400) {
+            $this->expectError('Ouch!');
+        } else {
+            $this->expectException(ErrorException::class, 'Ouch!');
+        }
         $mock->aMethod();
     }
 
@@ -991,7 +1000,11 @@ class TestOfThrowingErrorsFromMocks extends UnitTestCase
         $mock->errorOn('aMethod', 'Ouch!', [3]);
         $mock->aMethod(1);
         $mock->aMethod(2);
-        $this->expectError();
+        if (PHP_VERSION_ID < 80400) {
+            $this->expectError();
+        } else {
+            $this->expectException(ErrorException::class);
+        }
         $mock->aMethod(3);
     }
 
@@ -1001,7 +1014,12 @@ class TestOfThrowingErrorsFromMocks extends UnitTestCase
         $mock->errorAt(2, 'aMethod', 'Ouch!');
         $mock->aMethod();
         $mock->aMethod();
-        $this->expectError();
+        if (PHP_VERSION_ID < 80400) {
+            $this->expectError();
+        } else {
+            $this->expectException(ErrorException::class);
+        }
+
         $mock->aMethod();
     }
 }


### PR DESCRIPTION
The E_STRICT constant is only used if PHP version is less than 8.4;

Changed XMLParser setup:
- Removed the xml_set_object() function as deprecated as of 8.4;
- Passed callbacks as callable.

Explicitly set the nullable type of an optional parameter for PHP 8.4;

Wrote a wrapper for the trigger_error function:
- As of PHP 8.4, passing E_USER_ERROR to trigger_error() is deprecated and simpletest_trigger_error will throw an ErrorException instead;
- The errorLevel parameter is set to E_USER_NOTICE by default.