### PR TITLE
Making simpletest compatible with PHP 8.5

### DIFF
--- a/src/errors.php
+++ b/src/errors.php
@@ -119,12 +119,18 @@ class SimpleErrorQueue
      */
     public function tally()
     {
-        while (list($severity, $message, $file, $line) = $this->extract()) {
-            $severity = $this->getSeverityAsString($severity);
-            $this->test->error($severity, $message, $file, $line);
+        while ($error = $this->extract()) {
+            if (is_array($error)) {
+                list($severity, $message, $file, $line) = $error;
+                $severity = $this->getSeverityAsString($severity);
+                $this->test->error($severity, $message, $file, $line);
+            }
         }
-        while (list($expected, $message) = $this->extractExpectation()) {
-            $this->test->assert($expected, false, '%s -> Expected error not caught');
+        while ($expectation = $this->extractExpectation()) {
+            if (is_array($expectation)) {
+                list($expected, $message) = $expectation;
+                $this->test->assert($expected, false, '%s -> Expected error not caught');
+            }
         }
     }
 

--- a/src/expectation.php
+++ b/src/expectation.php
@@ -1011,7 +1011,11 @@ class MemberExpectation extends IdenticalExpectation
     {
         $reflection = new ReflectionObject($object);
         $property = $reflection->getProperty($name);
-        if (method_exists($property, 'setAccessible')) {
+        // Since PHP 8.1, all properties have been accessible by default.
+        // Since PHP 8.5, the setAccessible() method has been deprecated.
+        if (PHP_VERSION_ID < 80100 &&
+            method_exists($property, 'setAccessible'))
+        {
             $property->setAccessible(true);
         }
         try {

--- a/src/mock_objects.php
+++ b/src/mock_objects.php
@@ -1632,7 +1632,12 @@ class MockGenerator
                 $code .= ";\n";
             } else {
                 $code .= "\n    {\n";
-                $code .= "        return \$this->invoke(\"$method\", func_get_args());\n";
+                if (PHP_VERSION_ID >= 80200 && strpos($signature, ': void') !== false) {
+                    $code .= "        \$this->invoke(\"$method\", func_get_args());\n";
+                }
+                else {
+                    $code .= "        return \$this->invoke(\"$method\", func_get_args());\n";
+                }
                 $code .= "    }\n";
             }
         }


### PR DESCRIPTION
The setAccessible method is only used if PHP version is less than 8.1;

For PHP 8.2 and higher if the overriding method to be mocked up has the return type of void than there is no return before calling $this>invoke(), i.e. the method doesn't return anything;

Defined conditions in the while loops in a more strict manner.